### PR TITLE
C++11 requires a space between literal and identifier

### DIFF
--- a/tools/include/errorlist.h
+++ b/tools/include/errorlist.h
@@ -62,7 +62,7 @@ void endError(error **err);
 
 
 
-#define _DEBUGHERE_(extra,...) fprintf(stderr,"%s:("__FILE__":%d) "extra"\n",__func__,__LINE__,__VA_ARGS__);
+#define _DEBUGHERE_(extra,...) fprintf(stderr,"%s:("__FILE__":%d) " extra "\n",__func__,__LINE__,__VA_ARGS__);
 
 #define someErrorVA(errV,txt,prev,next,li,...) newErrorVA(errV,__func__,"("__FILE__":"#li")",txt,prev,next,__VA_ARGS__)
 #define topErrorVA(errV,txt,next,li,...)       someErrorVA(errV,txt,NULL,next,li,__VA_ARGS__)


### PR DESCRIPTION
This error prevents from building Glimpse with Clang, ref https://github.com/CosmoStat/Glimpse/pull/13.